### PR TITLE
Infra for building msvc compiler wrapper

### DIFF
--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -1,0 +1,21 @@
+on:
+  workflow_call:
+
+jobs:
+  build-file:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout Wrapper Source
+        uses: actions/checkout@v4
+        with:
+          repository: spack/msvc-wrapper
+          ref: v0.1.0
+          fetch-tags: true
+      # build and tests the wrapper
+      - name: Build Wrapper
+        run: |
+          cd msvc-wrapper
+          test\setup_and_drive_test.bat

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -15,6 +15,10 @@ jobs:
           ref: v0.1.0
           fetch-tags: true
           path: msvc-wrapper
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Remove Git Bash tools
+        run: |
+          rmdir /s /q "C:\Program Files\Git\usr"
       # build and tests the wrapper
       - name: Build Wrapper
         run: |

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -14,6 +14,7 @@ jobs:
           repository: spack/msvc-wrapper
           ref: v0.1.0
           fetch-tags: true
+          path: msvc-wrapper
       # build and tests the wrapper
       - name: Build Wrapper
         run: |

--- a/.github/workflows/test-resources.yml
+++ b/.github/workflows/test-resources.yml
@@ -52,3 +52,7 @@ jobs:
       (needs.build-mingw.result == 'success' || needs.build-mingw.result == 'skipped')
     needs: [build-mingw, changed]
     uses: ./.github/workflows/build-file.yml
+
+  build-msvc-wrapper:
+    name: "Msvc compiler wrapper build"
+    uses: ./.github/workflows/build-wrapper.yml

--- a/.github/workflows/update-resources.yml
+++ b/.github/workflows/update-resources.yml
@@ -50,3 +50,7 @@ jobs:
       (needs.build-upload-mingw.result == 'success' || needs.build-upload-mingw.result == 'skipped')
     needs: [build-upload-mingw, changed]
     uses: ./.github/workflows/update-file.yml
+
+  build-upload-msvc-wrapper:
+    name: "Build and upload the msvc compiler wrapper"
+    uses: ./.github/workflows/update-wrapper.yml

--- a/.github/workflows/update-wrapper.yml
+++ b/.github/workflows/update-wrapper.yml
@@ -14,6 +14,10 @@ jobs:
           repository: spack/msvc-wrapper
           ref: v0.1.0
           fetch-tags: true
+      - uses: ilammy/msvc-dev-cmd@v1
+      - name: Remove Git Bash tools
+        run: |
+          rmdir /s /q "C:\Program Files\Git\usr"
       # build and tests the wrapper
       - name: Build Wrapper
         run: |

--- a/.github/workflows/update-wrapper.yml
+++ b/.github/workflows/update-wrapper.yml
@@ -1,0 +1,43 @@
+on:
+  workflow_call:
+
+jobs:
+  build-file:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Checkout Wrapper Source
+        uses: actions/checkout@v4
+        with:
+          repository: spack/msvc-wrapper
+          ref: v0.1.0
+          fetch-tags: true
+      # build and tests the wrapper
+      - name: Build Wrapper
+        run: |
+          cd msvc-wrapper
+          test\setup_and_drive_test.bat
+      - name: Install Wrapper
+        run: |
+          cd msvc-wrapper
+          nmake install PREFIX=wrapper-install
+      - name: Bundle Wrapper
+        run: |
+          cd msvc-wrapper
+          tar -cz wrapper-install > msvc-wrapper-0.1.0.tar.gz
+      - name: Checkout pages
+        run: |
+          git fetch --all
+          git checkout -f -B pages --track origin/pages
+      - name: Config git user
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "Github Actions from commit ${{ github.sha }}"
+      - name: Upload
+        run: |
+          mkdir resources/msvc-wrapper/0.1.0
+          del /Q resources/msvc-wrapper/0.1.0/*
+          mv msvc-wrapper/msvc-wrapper-0.1.0.tar.gz resources/msvc-wrapper/0.1.0/msvc-wrapper_0.1.0.tar.gz
+          git add resources/msvc-wrapper/0.1.0/msvc-wrapper_0.1.0.tar.gz && git commit -m"Update msvc-wrapper binary" && git push -f


### PR DESCRIPTION
Builds, tests, installs, packages and uploads the MSVC compiler wrapper to the pages instance associated with this repo for use in Spack.

We're not building from source every time to avoid wasted cycles, and this is going here because we cannot rely on Spack's typical bootstrapping mechanism on Windows because we cannot get binary matching on Windows functional until https://github.com/spack/spack/pull/48821 lands.